### PR TITLE
Better messages

### DIFF
--- a/internal/builtin/events/message.go
+++ b/internal/builtin/events/message.go
@@ -1,8 +1,13 @@
 package builtin_ev
 
 import (
+	"fmt"
+	"log"
+	"time"
+
 	"github.com/Nykenik24/enkrypted/internal/event"
 	"github.com/Nykenik24/enkrypted/internal/user"
+	"github.com/Nykenik24/enkrypted/internal/ws"
 )
 
 var MessageEventKind = buildKind(RoomNamespace, "message")
@@ -12,16 +17,41 @@ type MessageEvent struct {
 	Timestamp string     `json:"timestamp"`
 	User      *user.User `json:"user"`
 	ID        uint64     `json:"id"`
+	RoomID    *uint64    `json:"roomId,omitempty"`
 }
 
-func NewMessageEvent(contents, timestamp string, user *user.User) *MessageEvent {
+func NewMessageEvent(contents, timestamp string, user *user.User, room *uint64) *MessageEvent {
 	lastMessageID++
 	return &MessageEvent{
 		Contents:  contents,
 		Timestamp: timestamp,
 		User:      user,
 		ID:        lastMessageID,
+		RoomID:    room,
 	}
+}
+
+func ValidateMessage(msg *MessageEvent) error {
+	if msg.ID < lastMessageID {
+		return fmt.Errorf("message's ID=%d is less than last message's ID=%d", msg.ID, lastMessageID)
+	}
+
+	lastMessageID++
+
+	log.Printf("message validated id=%d, lastId=%d", msg.ID, lastMessageID)
+
+	return nil
+}
+
+func BroadcastMessage(ctx *ws.Context, contents string) {
+	ctx.Broadcast(Generic(
+		NewMessageEvent(
+			contents,
+			time.Now().Format(time.RFC3339),
+			ctx.Client.GetUser(),
+			nil,
+		),
+	))
 }
 
 func (ev *MessageEvent) Data() *event.EventData {

--- a/internal/handlers/connect.go
+++ b/internal/handlers/connect.go
@@ -10,15 +10,7 @@ import (
 type ConnectHandler struct{}
 
 func (h *ConnectHandler) Handle(ctx *ws.Context) error {
-	ev := builtin_ev.NewMessageEvent(
-		fmt.Sprintf("user joined %s", ctx.Client.GetUser().Username),
-		time.Now().Format(time.RFC3339),
-		ctx.Client.GetUser(),
-	)
-
-	ctx.Broadcast(
-		builtin_ev.Generic(ev).ToAll(),
-	)
+	builtin_ev.BroadcastMessage(ctx, fmt.Sprintf("user joined %s", ctx.Client.GetUser().Username))
 
 	return nil
 }

--- a/internal/handlers/connect.go
+++ b/internal/handlers/connect.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"time"
 
 	builtin_ev "github.com/Nykenik24/enkrypted/internal/builtin/events"
 	"github.com/Nykenik24/enkrypted/internal/ws"

--- a/internal/handlers/create_room.go
+++ b/internal/handlers/create_room.go
@@ -32,11 +32,7 @@ func (h *CreateRoomHandler) Handle(ctx *ws.Context) error {
 		return err
 	}
 
-	ctx.Broadcast(builtin_ev.Generic(builtin_ev.NewMessageEvent(
-		"created room",
-		time.Now().Format(time.RFC3339),
-		ctx.Client.GetUser(),
-	)))
+	builtin_ev.BroadcastMessage(ctx, "created room")
 
 	return nil
 }

--- a/internal/handlers/create_room.go
+++ b/internal/handlers/create_room.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"time"
 
 	builtin_ev "github.com/Nykenik24/enkrypted/internal/builtin/events"
 	"github.com/Nykenik24/enkrypted/internal/ws"

--- a/internal/handlers/identify.go
+++ b/internal/handlers/identify.go
@@ -11,7 +11,7 @@ type IdentifyHandler struct{}
 func (h *IdentifyHandler) Handle(ctx *ws.Context) error {
 	var ev builtin_ev.IdentifyEvent
 
-	if err := ctx.Bind(&ev); err != nil {
+	if err := ctx.BindData(&ev); err != nil {
 		return err
 	}
 

--- a/internal/handlers/join.go
+++ b/internal/handlers/join.go
@@ -10,7 +10,7 @@ type JoinRoomHandler struct{}
 func (h *JoinRoomHandler) Handle(ctx *ws.Context) error {
 	var ev builtin_ev.JoinRoomEvent
 
-	if err := ctx.Bind(&ev); err != nil {
+	if err := ctx.BindData(&ev); err != nil {
 		return err
 	}
 

--- a/internal/handlers/leave.go
+++ b/internal/handlers/leave.go
@@ -10,7 +10,7 @@ type LeaveRoomHandler struct{}
 func (h *LeaveRoomHandler) Handle(ctx *ws.Context) error {
 	var ev builtin_ev.LeaveRoomEvent
 
-	if err := ctx.Bind(&ev); err != nil {
+	if err := ctx.BindData(&ev); err != nil {
 		return err
 	}
 

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -15,7 +15,7 @@ func (h *MessageHandler) Handle(ctx *ws.Context) error {
 		Contents string `json:"contents"`
 	}
 
-	if err := ctx.Bind(&msg); err != nil {
+	if err := ctx.BindData(&data); err != nil {
 		return err
 	}
 

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"time"
 
 	builtin_ev "github.com/Nykenik24/enkrypted/internal/builtin/events"
@@ -10,24 +11,31 @@ import (
 type MessageHandler struct{}
 
 func (h *MessageHandler) Handle(ctx *ws.Context) error {
-	var msg struct {
-		RoomID   uint64 `json:"roomId"`
-		Contents string `json:"contents"`
-	}
+	var data builtin_ev.MessageEvent
 
 	if err := ctx.BindData(&data); err != nil {
 		return err
 	}
 
-	ev := builtin_ev.NewMessageEvent(
-		msg.Contents,
-		time.Now().Format(time.RFC3339),
-		ctx.Client.GetUser(),
-	)
+	err := builtin_ev.ValidateMessage(&data)
+	if err != nil {
+		return err
+	}
 
-	ctx.Broadcast(
-		builtin_ev.Generic(ev).ToRoom(msg.RoomID),
-	)
+	if data.RoomID != nil {
+		ev := builtin_ev.NewMessageEvent(
+			data.Contents,
+			time.Now().Format(time.RFC3339),
+			ctx.Client.GetUser(),
+			data.RoomID,
+		)
+
+		ctx.Broadcast(
+			builtin_ev.Generic(ev).ToRoom(*data.RoomID),
+		)
+	} else {
+		return fmt.Errorf("TODO: global messages")
+	}
 
 	return nil
 }

--- a/internal/handlers/remove_room.go
+++ b/internal/handlers/remove_room.go
@@ -28,7 +28,7 @@ func (h *RemoveRoomHandler) Handle(ctx *ws.Context) error {
 	}
 
 	var data builtin_ev.RemoveRoomEvent
-	if err := ctx.Bind(&data); err != nil {
+	if err := ctx.BindData(&data); err != nil {
 		return err
 	}
 

--- a/internal/handlers/remove_room.go
+++ b/internal/handlers/remove_room.go
@@ -36,13 +36,7 @@ func (h *RemoveRoomHandler) Handle(ctx *ws.Context) error {
 		return err
 	}
 
-	ctx.Broadcast(builtin_ev.Generic(
-		builtin_ev.NewMessageEvent(
-			"removed room",
-			time.Now().Format(time.RFC3339),
-			ctx.Client.GetUser(),
-		),
-	))
+	builtin_ev.BroadcastMessage(ctx, fmt.Sprintf("removed room %d", data.RoomID))
 
 	return nil
 }

--- a/internal/handlers/remove_room.go
+++ b/internal/handlers/remove_room.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"time"
 
 	builtin_ev "github.com/Nykenik24/enkrypted/internal/builtin/events"
 	"github.com/Nykenik24/enkrypted/internal/ws"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ func (s *Server) GetRoom(id uint64) (ws.Room, error) {
 	if !ok {
 		return nil, fmt.Errorf("room %d not found", id)
 	}
+
 	return room, nil
 }
 

--- a/internal/ws/context.go
+++ b/internal/ws/context.go
@@ -11,7 +11,7 @@ type Context struct {
 	Server Server
 }
 
-func (ctx *Context) Bind(v any) error {
+func (ctx *Context) BindData(v any) error {
 	return ctx.Event.Decode(v)
 }
 


### PR DESCRIPTION
Message replay is now prohibited, as messages require an ID greater than the last message's ID.

A helper called `BroadcastMessage` was added for handlers that, after execution, broadcast a message to inform about what was done.

Messages now require the `roomId` property in JSON (or `RoomID` in `builtin_ev.MessageEvent`). 

Global messages are to be done, as they will require authorization (only admins will be able to globally send a message to all rooms) and also a bit of design (as maybe global messages won't even be allowed, at the end of the day message is inside the `room` namespace). For now, if a message has no ID an error is returned by the handler which says *TODO: global messages*.